### PR TITLE
Day 16 refactoring

### DIFF
--- a/AoC.Tests/Day16/Day16SolverTests.cs
+++ b/AoC.Tests/Day16/Day16SolverTests.cs
@@ -64,12 +64,10 @@ public class Day16SolverTests
     }
 
     [Test]
-    public void ReadPacketExample_LengthTypeId_0_ThatContains2SubPackets()
+    public void PacketDecode_Example_LengthTypeId_0_ThatContains2SubPackets()
     {
-        var reader = new BitsReader("38006F45291200");
-
         // ACT
-        var result = ReadPacket(reader);
+        var result = Packet.Decode("38006F45291200");
 
         // ASSERT
         using (new AssertionScope())
@@ -82,12 +80,10 @@ public class Day16SolverTests
     }
 
     [Test]
-    public void ReadPacketExample_LengthTypeId_1_ThatContains3SubPackets()
+    public void PacketDecode_Example_LengthTypeId_1_ThatContains3SubPackets()
     {
-        var reader = new BitsReader("EE00D40C823060");
-
         // ACT
-        var result = ReadPacket(reader);
+        var result = Packet.Decode("EE00D40C823060");
 
         // ASSERT
         using (new AssertionScope())

--- a/AoC.Tests/Day16/Day16SolverTests.cs
+++ b/AoC.Tests/Day16/Day16SolverTests.cs
@@ -12,7 +12,7 @@ public class Day16SolverTests
     [TestCase("EE00D40C823060", 7, 3)]
     public void BitsReader_ReadHeader_Tests(string input, int expectedVersion, int expectedTypeId)
     {
-        using var reader = new BitsReader(input);
+        var reader = new BitsReader(input);
 
         // ACT
         var (packetVersion, packetTypeId) = reader.ReadHeader();
@@ -25,7 +25,7 @@ public class Day16SolverTests
     [Test]
     public void PacketExample1_RepresentsLiteralValue_2021()
     {
-        using var reader = new BitsReader("D2FE28");
+        var reader = new BitsReader("D2FE28");
 
         // ACT
         var (packetVersion, packetTypeId) = reader.ReadHeader();
@@ -41,9 +41,32 @@ public class Day16SolverTests
     }
 
     [Test]
+    public void BitsReader_IncrementsBitPointer_And_EndReturnsTrueWhenEndIsReached_AndThrowsExceptionIfAttemptToReadAfterEndIsReached()
+    {
+        var reader = new BitsReader("F");
+
+        // ACT & ASSERT
+        reader.BitPointer.Should().Be(0);
+
+        for (var i = 1; i <= 3; i++)
+        {
+            reader.ReadBit();
+            reader.BitPointer.Should().Be(i);
+            reader.End.Should().BeFalse();
+        }
+
+        reader.ReadBit();
+        reader.BitPointer.Should().Be(4);
+        reader.End.Should().BeTrue();
+
+        var finalAct = () => reader.ReadBit();
+        finalAct.Should().Throw<InvalidOperationException>().WithMessage("End of transmission reached");
+    }
+
+    [Test]
     public void ReadPacketExample_LengthTypeId_0_ThatContains2SubPackets()
     {
-        using var reader = new BitsReader("38006F45291200");
+        var reader = new BitsReader("38006F45291200");
 
         // ACT
         var result = ReadPacket(reader);
@@ -61,7 +84,7 @@ public class Day16SolverTests
     [Test]
     public void ReadPacketExample_LengthTypeId_1_ThatContains3SubPackets()
     {
-        using var reader = new BitsReader("EE00D40C823060");
+        var reader = new BitsReader("EE00D40C823060");
 
         // ACT
         var result = ReadPacket(reader);

--- a/AoC/Day16/Day16Solver.cs
+++ b/AoC/Day16/Day16Solver.cs
@@ -32,13 +32,12 @@ public class Day16Solver : SolverBase
         {
             // Every other type of packet (any packet with a type ID other than 4) represent an operator
             // that performs some calculation on one or more sub-packets contained within
-            var lengthTypeId = reader.Read().IsSet ? 1 : 0;
+            var lengthTypeId = reader.ReadBit().IsSet ? 1 : 0;
 
             if (lengthTypeId == 0)
             {
                 // the next 15 bits are a number that represents the total length in bits of the sub-packets contained by this packet
                 var subPacketsBitLength = reader.ReadNumber(15);
-
                 var end = reader.CountOfBitsRead + subPacketsBitLength;
 
                 while (reader.CountOfBitsRead < end)
@@ -84,7 +83,7 @@ public class Day16Solver : SolverBase
 
         public int CountOfBitsRead { get; set; }
 
-        public BitsReader(PuzzleInput input) => _bitReader = ReadBits(ReadBytes(input)).GetEnumerator();
+        public BitsReader(PuzzleInput input) => _bitReader = BytesToBits(HexInputToBytes(input)).GetEnumerator();
 
         public void Dispose() => _bitReader.Dispose();
 
@@ -97,16 +96,16 @@ public class Day16Solver : SolverBase
             bool keepReading;
             do
             {
-                keepReading = Read();
-                bits.AddRange(Read(4));
+                keepReading = ReadBit();
+                bits.AddRange(ReadBits(4));
             } while (keepReading);
 
             return BitsToLong(bits);
         }
 
-        public int ReadNumber(int bitLength) => BitsToInt(Read(bitLength));
+        public int ReadNumber(int bitLength) => BitsToInt(ReadBits(bitLength));
 
-        public Bit Read()
+        public Bit ReadBit()
         {
             if (!_bitReader.MoveNext())
             {
@@ -117,11 +116,11 @@ public class Day16Solver : SolverBase
             return _bitReader.Current;
         }
 
-        private IEnumerable<Bit> Read(int numBits)
+        private IEnumerable<Bit> ReadBits(int numBits)
         {
             for (var i = 0; i < numBits; i++)
             {
-                yield return Read();
+                yield return ReadBit();
             }
         }
 
@@ -129,9 +128,9 @@ public class Day16Solver : SolverBase
 
         private static long BitsToLong(IEnumerable<Bit> bits) => Convert.ToInt64(string.Join("", bits), 2);
 
-        private static IEnumerable<byte> ReadBytes(PuzzleInput input) => input.ToString().Select(chr => Convert.ToByte(chr.ToString(), 16));
+        private static IEnumerable<byte> HexInputToBytes(PuzzleInput input) => input.ToString().Select(chr => Convert.ToByte(chr.ToString(), 16));
 
-        private static IEnumerable<Bit> ReadBits(IEnumerable<byte> bytes) =>
+        private static IEnumerable<Bit> BytesToBits(IEnumerable<byte> bytes) =>
             bytes.SelectMany(b => Convert.ToString(b, 2).PadLeft(4, '0').Select(c => new Bit(c is '1')));
 
         public readonly record struct Bit(bool IsSet)


### PR DESCRIPTION
* Minor naming improvements in BitsReader
* Changed BitsReader in Day 16 to use a pointer over an array, rather than a forward only reader, so its easier to debug and see what is happening.  Slightly less performing, but that is minuscule and worth the benefit of easily debugging.
* Refactored the Day 16 ReadPacket method so that its part of the Packet class, to make it more easily usable, just in case this does need to be pulled out in a following day